### PR TITLE
Ft exercise cache when deleting muscles 152919276

### DIFF
--- a/wger/exercises/views/muscles.py
+++ b/wger/exercises/views/muscles.py
@@ -115,6 +115,6 @@ class MuscleDeleteView(WgerDeleteMixin, LoginRequiredMixin, PermissionRequiredMi
         Send some additional data to the template
         '''
         context = super(MuscleDeleteView, self).get_context_data(**kwargs)
-        context['title'] = _(u'Delete {0}?').format(self.object.name)
         context['form_action'] = reverse('exercise:muscle:delete', kwargs={'pk': self.kwargs['pk']})
+        context['title'] = _(u'Delete {0}?').format(self.object.name)
         return context

--- a/wger/exercises/views/muscles.py
+++ b/wger/exercises/views/muscles.py
@@ -119,10 +119,5 @@ class MuscleDeleteView(WgerDeleteMixin, LoginRequiredMixin, PermissionRequiredMi
         context = super(MuscleDeleteView, self).get_context_data(**kwargs)
         context['form_action'] = reverse('exercise:muscle:delete', kwargs={'pk': self.kwargs['pk']})
         context['title'] = _(u'Delete {0}?').format(self.object.name)
-<<<<<<< HEAD
-        exercise_id = 0
-        exercises = Exercise.objects.all()
         cache.clear()
-=======
->>>>>>> Change order of delete execution.
         return context

--- a/wger/exercises/views/muscles.py
+++ b/wger/exercises/views/muscles.py
@@ -16,6 +16,7 @@
 import logging
 
 from django.contrib.auth.mixins import PermissionRequiredMixin, LoginRequiredMixin
+from django.core.cache import cache
 from django.core.urlresolvers import reverse, reverse_lazy
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
@@ -27,7 +28,8 @@ from django.views.generic import (
     UpdateView
 )
 
-from wger.exercises.models import Muscle
+from wger.exercises.models import Muscle, Exercise
+from wger.utils.cache import cache_mapper
 from wger.utils.generic_views import (
     WgerFormMixin,
     WgerDeleteMixin
@@ -117,4 +119,7 @@ class MuscleDeleteView(WgerDeleteMixin, LoginRequiredMixin, PermissionRequiredMi
         context = super(MuscleDeleteView, self).get_context_data(**kwargs)
         context['form_action'] = reverse('exercise:muscle:delete', kwargs={'pk': self.kwargs['pk']})
         context['title'] = _(u'Delete {0}?').format(self.object.name)
+        exercise_id = 0
+        exercises = Exercise.objects.all()
+        cache.clear()
         return context

--- a/wger/exercises/views/muscles.py
+++ b/wger/exercises/views/muscles.py
@@ -119,7 +119,10 @@ class MuscleDeleteView(WgerDeleteMixin, LoginRequiredMixin, PermissionRequiredMi
         context = super(MuscleDeleteView, self).get_context_data(**kwargs)
         context['form_action'] = reverse('exercise:muscle:delete', kwargs={'pk': self.kwargs['pk']})
         context['title'] = _(u'Delete {0}?').format(self.object.name)
+<<<<<<< HEAD
         exercise_id = 0
         exercises = Exercise.objects.all()
         cache.clear()
+=======
+>>>>>>> Change order of delete execution.
         return context


### PR DESCRIPTION
**What does this PR do?**

It resets the cache when a user deletes a muscle.

**Description of Task to be completed?**

When a muscle is deleted, the cache is reset and removed from the muscle overview, descriptions etc.

**How to manually test the feature ?**

Delete a muscle form the muscle admin overview. Then go and check for the muscle deleted in muscle overviews and in the descriptions via exercises. The muscle should not be there.

**What are the relevant pivotal tracker stories?**

#152919276