### PR TITLE
Ft allow managers to delete or deactivate trainers 152919287

### DIFF
--- a/wger/core/views/user.py
+++ b/wger/core/views/user.py
@@ -82,6 +82,7 @@ def login(request):
                             extra_context=context)
 
 
+# view to Delete user account
 @login_required()
 def delete(request, user_pk=None):
     '''
@@ -307,6 +308,7 @@ def preferences(request):
         return render(request, 'user/preferences.html', template_data)
 
 
+# view to deactivate user
 class UserDeactivateView(LoginRequiredMixin,
                          WgerMultiplePermissionRequiredMixin,
                          RedirectView):
@@ -340,6 +342,7 @@ class UserDeactivateView(LoginRequiredMixin,
         return reverse('core:user:overview', kwargs=({'pk': pk}))
 
 
+# view to activate user
 class UserActivateView(LoginRequiredMixin,
                        WgerMultiplePermissionRequiredMixin,
                        RedirectView):

--- a/wger/gym/templates/gym/member_list.html
+++ b/wger/gym/templates/gym/member_list.html
@@ -26,7 +26,9 @@
     <th style="width: 10%;">{% trans "ID" %}</th>
     <th style="width: 40%;">{% trans "Username" %}</th>
     <th>{% trans "Name" %}</th>
+    <th>{% trans "Status" %}</th>
     {% if perms.gym.manage_gym or perms.gym.manage_gyms %}
+        <th style="text-align: right;">{% trans "Actions" %}</th>
         <th style="text-align: right;">{% trans "Roles" %}</th>
     {% endif %}
 </tr>
@@ -53,8 +55,48 @@
         {% endif %}
     </td>
     <td>
+      {% if not current_user.perms.manage_gym and not current_user.perms.manage_gyms %}
+        <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj.get_full_name}}</a>
+      {% else %}
         {{current_user.obj.get_full_name}}
+      {% endif %}
     </td>
+    <td>
+      {% if current_user.obj.is_active%}
+        Active
+      {% else %}
+        Inactive
+      {% endif %}
+    </td>
+
+    {% if perms.gym.manage_gym or perms.gym.manage_gyms %}
+    <td style="text-align: right;">
+        <div class="btn-group pull-right">
+          {% if not current_user.perms.manage_gym and not current_user.perms.manage_gyms %}
+            <button type="button" class="btn btn-default dropdown-toggle btn-xs" data-toggle="dropdown">
+                <span class="{% fa_class 'cogs' %}"></span>
+            </button>
+          {% endif %}
+            <ul class="dropdown-menu" role="menu">
+                {% if not current_user.perms.manage_gym and not current_user.perms.manage_gyms %}
+                {% if current_user.obj.is_active %}
+                    <li>
+                    <a href="{% url 'core:user:deactivate' current_user.obj.pk %}">{% trans 'Deactivate' %}</a>
+                </li>
+                {% else %}
+                <li>
+                    <a href="{% url 'core:user:activate' current_user.obj.pk %}">{% trans 'Activate' %}</a>
+                </li>
+                {% endif %}
+                <li>
+                    <a href="{% url 'core:user:delete' current_user.obj.pk %}" class="wger-modal-dialog">{% trans 'Delete' %}</a>
+                </li>
+                {% endif %}
+            </ul>
+        </div>
+
+    </td>
+    {% endif %}
 
     {% if perms.gym.manage_gym or perms.gym.manage_gyms %}
     <td style="text-align: right;">

--- a/wger/gym/templates/gym/member_list.html
+++ b/wger/gym/templates/gym/member_list.html
@@ -40,7 +40,11 @@
         {{current_user.obj.pk}}
     </td>
     <td>
-        {{current_user.obj}}
+        {% if not current_user.perms.manage_gym and not current_user.perms.manage_gyms %}
+          <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj}}</a>
+        {% else %}
+          {{current_user.obj}}
+        {% endif %}
 
         {% if current_user.perms.gym_trainer %}
             <span class="label label-primary">{% trans "Trainer" %}</span>
@@ -55,11 +59,7 @@
         {% endif %}
     </td>
     <td>
-      {% if not current_user.perms.manage_gym and not current_user.perms.manage_gyms %}
-        <a href="{% url 'core:user:overview' current_user.obj.pk %}">{{current_user.obj.get_full_name}}</a>
-      {% else %}
         {{current_user.obj.get_full_name}}
-      {% endif %}
     </td>
     <td>
       {% if current_user.obj.is_active%}

--- a/wger/gym/templates/gym/partial_user_list.html
+++ b/wger/gym/templates/gym/partial_user_list.html
@@ -14,7 +14,7 @@ $(document).ready( function () {
 });
 
 $(document).ready(function(){
-	
+
 	$('ul.tabs li').click(function(){
 		var tab_id = $(this).attr('data-tab');
 
@@ -58,7 +58,7 @@ ul.tabs li.current{
 }
 </style>
 
-<div class="container">
+<div class="">
 
 	<ul class="tabs">
 		<li class="tab-link current" data-tab="tab-1">Overview</li>
@@ -100,7 +100,7 @@ ul.tabs li.current{
                                 -/-
                             {% endif %}
                         </td>
-                        
+
                         {% endif %}
                     </tr>
                     {% endfor %}
@@ -142,7 +142,7 @@ ul.tabs li.current{
                                 -/-
                             {% endif %}
                         </td>
-                        
+
                         {% endif %}
                     </tr>
                     {% endif %}


### PR DESCRIPTION
#### What does this PR do?
It allows gym managers to delete or deactivate trainers.
#### Description of Task to be completed?
Currently, a manager cannot delete or deactivate trainers from a gym.
With this feature, they will be able to do this.
#### How should this be manually tested?
    - Login as admin.
    - Create a new gym and add a gym administrator.
    - Log in as the gym administrator you just added.
    - Navigate to the gym created above as the gym administrator.
    - Add a trainer to the gym.
    - On the overview click the cogs icon below the Action heading.
    - Click Deactivate.
    - to delete, on the overview click the cogs icon below the Action heading of a deactivated user.
    - Click Delete.

#### What are the relevant pivotal tracker stories?
[#152919285](https://www.pivotaltracker.com/story/show/152919285)